### PR TITLE
add support for the :retry_count and :retry_backoff_ms options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.0
+ - Fixed plugin crash upon socket write exception [#10](https://github.com/logstash-plugins/logstash-output-udp/pull/10)
+ - Added support for the 'retry_count' and 'retry_backoff_ms' options [#12](https://github.com/logstash-plugins/logstash-output-udp/pull/12)
+
 ## 3.0.6
   - Docs: Set the default_codec doc attribute.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -23,7 +23,14 @@ include::{include_path}/plugin_header.asciidoc[]
 
 Send events over UDP
 
-Keep in mind that UDP will lose messages.
+Keep in mind that UDP does not provide delivery or duplicate protection guarantees.
+Even when this plugin succeeds at writing to the UDP socket, there is no guarantee that
+the recipient will receive exactly one copy of the event.
+
+When this plugin fails to write to the UDP socket, by default the event will be dropped
+and the error message will be logged. The <<plugins-{type}s-{plugin}-retry_count>> option
+in conjunction with the <<plugins-{type}s-{plugin}-retry_backoff_ms>> option can be used
+to retry a failed write for a number of times before dropping the event.
 
 [id="plugins-{type}s-{plugin}-options"]
 ==== Udp Output Configuration Options
@@ -35,6 +42,8 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-host>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-port>> |<<number,number>>|Yes
+| <<plugins-{type}s-{plugin}-retry_count>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-retry_backoff_ms>> |<<number,number>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -60,7 +69,21 @@ The address to send messages to
 
 The port to send messages on
 
+[id="plugins-{type}s-{plugin}-retry_count"]
+===== `retry_count`
 
+* Value type is <<number,number>>
+* Default value is `0`
+
+The number of times to retry a failed UPD socket write
+
+[id="plugins-{type}s-{plugin}-retry_backoff_ms"]
+===== `retry_backoff_ms`
+
+* Value type is <<number,number>>
+* Default value is `10`
+
+The amount of time to wait in milliseconds before attempting to retry a failed UPD socket write
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/lib/logstash/outputs/udp.rb
+++ b/lib/logstash/outputs/udp.rb
@@ -5,7 +5,7 @@ require "socket"
 
 # Send events over UDP
 #
-# Keep in mind that UDP will lose messages.
+# Keep in mind that UDP is a lossy protocol
 class LogStash::Outputs::UDP < LogStash::Outputs::Base
   config_name "udp"
   
@@ -17,15 +17,39 @@ class LogStash::Outputs::UDP < LogStash::Outputs::Base
   # The port to send messages on
   config :port, :validate => :number, :required => true
 
-  public
+  # The number of times to retry a failed UPD socket write
+  config :retry_count, :validate => :number, :default => 0
+
+  # The amount of time to wait in milliseconds before attempting to retry a failed UPD socket write
+  config :retry_backoff_ms, :validate => :number, :default => 100
+
   def register
     @socket = UDPSocket.new
+
     @codec.on_event do |event, payload|
-      begin
-        @socket.send(payload, 0, @host, @port)
-      rescue Errno::EMSGSIZE => e
-        logger.error("Failed to send event, message size of #{payload.size} too long", error_hash(e, payload))
-      rescue => e
+      socket_send(payload)
+    end
+  end
+
+  def receive(event)
+    @codec.encode(event)
+  end
+
+  private
+
+  def socket_send(payload)
+    send_count = 0
+    begin
+      send_count += 1
+      @socket.send(payload, 0, @host, @port)
+    rescue Errno::EMSGSIZE => e
+      logger.error("Failed to send event, message size of #{payload.size} too long", error_hash(e, payload))
+    rescue => e
+      if @retry_count > 0 && send_count <= @retry_count
+        logger.warn("Failed to send event, retrying:", error_hash(e, payload))
+        sleep(@retry_backoff_ms / 1000.0)
+        retry
+      else
         logger.error("Failed to send event:", error_hash(e, payload))
       end
     end
@@ -34,21 +58,17 @@ class LogStash::Outputs::UDP < LogStash::Outputs::Base
   MAX_DEBUG_PAYLOAD = 1000
 
   def error_hash(error, payload)
-    error_hash = {:error => error.inspect,
-                  :backtrace => error.backtrace.first(10)
-                 }
+    error_hash = {
+      :error => error.inspect,
+      :backtrace => error.backtrace.first(10)
+    }
     if logger.debug?
-      error_hash.merge(:event_payload =>
-                       payload.length > MAX_DEBUG_PAYLOAD ? "#{payload[0...MAX_DEBUG_PAYLOAD]}...<TRUNCATED>" : payload
-                      )
+      error_hash.merge(
+        :event_payload =>
+        payload.length > MAX_DEBUG_PAYLOAD ? "#{payload[0...MAX_DEBUG_PAYLOAD]}...<TRUNCATED>" : payload
+      )
     else
       error_hash
     end
   end
-
-  def receive(event)
-    return if event == LogStash::SHUTDOWN
-    @codec.encode(event)
-  end
-
-end # class LogStash::Outputs::Stdout
+end

--- a/logstash-output-udp.gemspec
+++ b/logstash-output-udp.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-udp'
-  s.version         = '3.0.6'
+  s.version         = '3.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Sends events over UDP"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Fixes #11 
Relates to #10 

Adds support for the `:retry_count` and `:retry_backoff_ms` options.

To preserve BWC `:retry_count` is `0` by default. 